### PR TITLE
feat: finer FTB Quests toast control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.gradle/
 /libs/
 /.idea/
+/.vscode/

--- a/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastConfigData.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastConfigData.java
@@ -1,9 +1,14 @@
 package net.bivrik.fancytoasts.client.config.data;
 
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+
 import net.bivrik.fancytoasts.client.config.ConfigHandler;
 import net.bivrik.fancytoasts.client.registry.AnimationRegistry;
 import net.bivrik.fancytoasts.client.registry.TextureRegistry;
 import net.bivrik.fancytoasts.core.Constants;
+import net.bivrik.fancytoasts.platform.utility.FancyQuestType;
 import net.bivrik.fancytoasts.platform.utility.FancyToastType;
 import net.bivrik.fancytoasts.utility.DefaultLocations;
 import net.bivrik.fancytoasts.utility.file.Paths;
@@ -11,30 +16,32 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.Objects;
-
 public class ToastConfigData extends ConfigData {
     private static final int VERSION = Constants.ConfigVersions.TOAST;
 
     private ResourceLocation textureId;
     private ResourceLocation animationId;
     private final Map<FancyToastType, ResourceLocation> soundIds = new EnumMap<>(FancyToastType.class);
+    private final Map<FancyQuestType, ResourceLocation> questSoundIds = new EnumMap<>(FancyQuestType.class);
 
-    private ToastConfigData(ResourceLocation textureId, ResourceLocation animationId, Map<FancyToastType, ResourceLocation> soundIds) {
+    private ToastConfigData(ResourceLocation textureId, ResourceLocation animationId, Map<FancyToastType, ResourceLocation> soundIds, Map<FancyQuestType, ResourceLocation> questSoundIds) {
         super(Paths.TOAST_CONFIG_FILE);
 
         this.textureId = textureId;
         this.animationId = animationId;
         this.soundIds.putAll(soundIds);
+        this.questSoundIds.putAll(questSoundIds);
     }
 
     public ToastConfigData() {
         this(DefaultLocations.Textures.VANILLA, DefaultLocations.Animations.STANDARD, Map.of(
                 FancyToastType.TASK, SoundEvents.ALLAY_AMBIENT_WITH_ITEM.getLocation(),
                 FancyToastType.GOAL, SoundEvents.FIREWORK_ROCKET_TWINKLE_FAR.getLocation(),
-                FancyToastType.CHALLENGE, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE.getLocation()));
+                FancyToastType.CHALLENGE, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE.getLocation()), Map.of(
+                FancyQuestType.TASK, SoundEvents.PLAYER_LEVELUP.getLocation(),
+                FancyQuestType.QUEST, SoundEvents.ALLAY_AMBIENT_WITH_ITEM.getLocation(),
+                FancyQuestType.CHAPTER, SoundEvents.FIREWORK_ROCKET_TWINKLE_FAR.getLocation(),
+                FancyQuestType.BOOK, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE.getLocation()));
     }
 
     public ResourceLocation getTextureId() {
@@ -77,6 +84,24 @@ public class ToastConfigData extends ConfigData {
         soundIds.put(type, location);
     }
 
+    public ResourceLocation getSoundIdByQuestType(FancyQuestType type) {
+        var availableSounds = Minecraft.getInstance().getSoundManager().getAvailableSounds();
+        ResourceLocation soundId = questSoundIds.get(type);
+
+        if (!availableSounds.contains(soundId)) {
+            ResourceLocation standardSoundId = new ToastConfigData().questSoundIds.get(type);
+            putSoundIdForQuestType(standardSoundId, type);
+            ConfigHandler.save(copy());
+            return standardSoundId;
+        }
+
+        return questSoundIds.get(type);
+    }
+
+    public void putSoundIdForQuestType(ResourceLocation location, FancyQuestType type) {
+        questSoundIds.put(type, location);
+    }
+
     @Override
     public boolean isValid() {
         boolean isValid = true;
@@ -104,24 +129,24 @@ public class ToastConfigData extends ConfigData {
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ToastConfigData that)) return false;
-        return Objects.equals(textureId, that.textureId) && Objects.equals(animationId, that.animationId) && Objects.equals(soundIds, that.soundIds);
+        return Objects.equals(textureId, that.textureId) && Objects.equals(animationId, that.animationId) && Objects.equals(soundIds, that.soundIds) && Objects.equals(questSoundIds, that.questSoundIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(textureId, animationId, soundIds);
+        return Objects.hash(textureId, animationId, soundIds, questSoundIds);
     }
 
     @Override
     public ToastConfigData copy() {
-        return new ToastConfigData(textureId, animationId, soundIds).withLatestVersion();
+        return new ToastConfigData(textureId, animationId, soundIds, questSoundIds).withLatestVersion();
     }
 
     @Override
     public String toString() {
         return super.toString().replace("}", ", ") + String.format(
-                "textureId='%s', animationId='%s', soundIds='%s'}",
-                textureId, animationId, soundIds
+            "textureId='%s', animationId='%s', soundIds='%s', questSoundIds='%s'}",
+            textureId, animationId, soundIds, questSoundIds
         );
     }
 }

--- a/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastConfigData.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastConfigData.java
@@ -38,7 +38,7 @@ public class ToastConfigData extends ConfigData {
                 FancyToastType.TASK, SoundEvents.ALLAY_AMBIENT_WITH_ITEM.getLocation(),
                 FancyToastType.GOAL, SoundEvents.FIREWORK_ROCKET_TWINKLE_FAR.getLocation(),
                 FancyToastType.CHALLENGE, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE.getLocation()), Map.of(
-                FancyQuestType.TASK, SoundEvents.PLAYER_LEVELUP.getLocation(),
+                FancyQuestType.TASK, SoundEvents.ALLAY_ITEM_GIVEN.getLocation(),
                 FancyQuestType.QUEST, SoundEvents.ALLAY_AMBIENT_WITH_ITEM.getLocation(),
                 FancyQuestType.CHAPTER, SoundEvents.FIREWORK_ROCKET_TWINKLE_FAR.getLocation(),
                 FancyQuestType.BOOK, SoundEvents.UI_TOAST_CHALLENGE_COMPLETE.getLocation()));

--- a/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastsFilteringData.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastsFilteringData.java
@@ -2,7 +2,6 @@ package net.bivrik.fancytoasts.client.config.data;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import net.bivrik.fancytoasts.core.Constants;
+import net.bivrik.fancytoasts.platform.utility.FancyQuestType;
 import net.bivrik.fancytoasts.platform.utility.FancyToastType;
 import net.bivrik.fancytoasts.utility.file.Paths;
 import net.minecraft.resources.ResourceLocation;
@@ -26,13 +26,13 @@ public class ToastsFilteringData extends ConfigData {
 
     // Only set on load, changing through config file
     private final Map<FancyToastType, Boolean> typesToIgnore = new EnumMap<>(FancyToastType.class);
-    private final Map<String, Boolean> questTypesToIgnore = new HashMap<>();
+    private final Map<FancyQuestType, Boolean> questTypesToIgnore = new EnumMap<>(FancyQuestType.class);
     private final List<String> toastsToIgnore = new ArrayList<>();
 
     private final transient Set<String> exactMatches = new HashSet<>();
     private final transient Set<String> prefixMatches = new HashSet<>();
 
-    private ToastsFilteringData(boolean fancyAdvancementToastsEnabled, boolean fancyQuestToastsEnabled, boolean advancementToastsEnabled, boolean recipeToastsEnabled, boolean systemToastsEnabled, boolean tutorialToastsEnabled, Map<FancyToastType, Boolean> typesToIgnore, List<String> toastsToIgnore, Map<String, Boolean> questTypesToIgnore) {
+    private ToastsFilteringData(boolean fancyAdvancementToastsEnabled, boolean fancyQuestToastsEnabled, boolean advancementToastsEnabled, boolean recipeToastsEnabled, boolean systemToastsEnabled, boolean tutorialToastsEnabled, Map<FancyToastType, Boolean> typesToIgnore, List<String> toastsToIgnore, Map<FancyQuestType, Boolean> questTypesToIgnore) {
         super(Paths.TOASTS_FILTERING_FILE);
 
         this.fancyAdvancementToastsEnabled = fancyAdvancementToastsEnabled;
@@ -60,10 +60,10 @@ public class ToastsFilteringData extends ConfigData {
             FancyToastType.GOAL, false,
             FancyToastType.CHALLENGE, false
         ), new ArrayList<>(), Map.of(
-            "BOOK", false,
-            "CHAPTER", false,
-            "QUEST", false,
-            "TASK", false
+            FancyQuestType.BOOK, false,
+            FancyQuestType.CHAPTER, false,
+            FancyQuestType.QUEST, false,
+            FancyQuestType.TASK, false
         ));
         }
 
@@ -71,7 +71,7 @@ public class ToastsFilteringData extends ConfigData {
         return typesToIgnore.get(type);
     }
 
-    public boolean isQuestTypeIgnored(String key) {
+    public boolean isQuestTypeIgnored(FancyQuestType key) {
         return questTypesToIgnore.getOrDefault(key, false);
     }
 

--- a/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastsFilteringData.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/config/data/ToastsFilteringData.java
@@ -1,11 +1,18 @@
 package net.bivrik.fancytoasts.client.config.data;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
 import net.bivrik.fancytoasts.core.Constants;
 import net.bivrik.fancytoasts.platform.utility.FancyToastType;
 import net.bivrik.fancytoasts.utility.file.Paths;
 import net.minecraft.resources.ResourceLocation;
-
-import java.util.*;
 
 public class ToastsFilteringData extends ConfigData {
     private static final int VERSION = Constants.ConfigVersions.TOAST_FILTERING;
@@ -19,12 +26,13 @@ public class ToastsFilteringData extends ConfigData {
 
     // Only set on load, changing through config file
     private final Map<FancyToastType, Boolean> typesToIgnore = new EnumMap<>(FancyToastType.class);
+    private final Map<String, Boolean> questTypesToIgnore = new HashMap<>();
     private final List<String> toastsToIgnore = new ArrayList<>();
 
     private final transient Set<String> exactMatches = new HashSet<>();
     private final transient Set<String> prefixMatches = new HashSet<>();
 
-    private ToastsFilteringData(boolean fancyAdvancementToastsEnabled, boolean fancyQuestToastsEnabled, boolean advancementToastsEnabled, boolean recipeToastsEnabled, boolean systemToastsEnabled, boolean tutorialToastsEnabled, Map<FancyToastType, Boolean> typesToIgnore, List<String> toastsToIgnore) {
+    private ToastsFilteringData(boolean fancyAdvancementToastsEnabled, boolean fancyQuestToastsEnabled, boolean advancementToastsEnabled, boolean recipeToastsEnabled, boolean systemToastsEnabled, boolean tutorialToastsEnabled, Map<FancyToastType, Boolean> typesToIgnore, List<String> toastsToIgnore, Map<String, Boolean> questTypesToIgnore) {
         super(Paths.TOASTS_FILTERING_FILE);
 
         this.fancyAdvancementToastsEnabled = fancyAdvancementToastsEnabled;
@@ -36,6 +44,7 @@ public class ToastsFilteringData extends ConfigData {
 
         this.typesToIgnore.putAll(typesToIgnore);
         this.toastsToIgnore.addAll(toastsToIgnore);
+        this.questTypesToIgnore.putAll(questTypesToIgnore);
         for (String toastToIgnore : this.toastsToIgnore) {
             if (toastToIgnore.endsWith("/...")) {
                 prefixMatches.add(toastToIgnore.replace("/...", ""));
@@ -45,16 +54,25 @@ public class ToastsFilteringData extends ConfigData {
         }
     }
 
-    public ToastsFilteringData() {
+        public ToastsFilteringData() {
         this(true, true, true, true, true, true, Map.of(
-                FancyToastType.TASK, false,
-                FancyToastType.GOAL, false,
-                FancyToastType.CHALLENGE, false
-        ), new ArrayList<>());
-    }
+            FancyToastType.TASK, false,
+            FancyToastType.GOAL, false,
+            FancyToastType.CHALLENGE, false
+        ), new ArrayList<>(), Map.of(
+            "BOOK", false,
+            "CHAPTER", false,
+            "QUEST", false,
+            "TASK", false
+        ));
+        }
 
     public boolean isTypeIgnored(FancyToastType type) {
         return typesToIgnore.get(type);
+    }
+
+    public boolean isQuestTypeIgnored(String key) {
+        return questTypesToIgnore.getOrDefault(key, false);
     }
 
     public boolean isToastIgnored(ResourceLocation toastLocation) {
@@ -118,12 +136,12 @@ public class ToastsFilteringData extends ConfigData {
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof ToastsFilteringData that)) return false;
-        return fancyAdvancementToastsEnabled == that.fancyAdvancementToastsEnabled && fancyQuestToastsEnabled == that.fancyQuestToastsEnabled && advancementToastsEnabled == that.advancementToastsEnabled && recipeToastsEnabled == that.recipeToastsEnabled && systemToastsEnabled == that.systemToastsEnabled && tutorialToastsEnabled == that.tutorialToastsEnabled && Objects.equals(typesToIgnore, that.typesToIgnore) && Objects.equals(toastsToIgnore, that.toastsToIgnore);
+        return fancyAdvancementToastsEnabled == that.fancyAdvancementToastsEnabled && fancyQuestToastsEnabled == that.fancyQuestToastsEnabled && advancementToastsEnabled == that.advancementToastsEnabled && recipeToastsEnabled == that.recipeToastsEnabled && systemToastsEnabled == that.systemToastsEnabled && tutorialToastsEnabled == that.tutorialToastsEnabled && Objects.equals(typesToIgnore, that.typesToIgnore) && Objects.equals(questTypesToIgnore, that.questTypesToIgnore) && Objects.equals(toastsToIgnore, that.toastsToIgnore);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, toastsToIgnore);
+        return Objects.hash(fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, questTypesToIgnore, toastsToIgnore);
     }
 
     @Override
@@ -133,14 +151,14 @@ public class ToastsFilteringData extends ConfigData {
 
     @Override
     public ToastsFilteringData copy() {
-        return new ToastsFilteringData(fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, toastsToIgnore).withLatestVersion();
+        return new ToastsFilteringData(fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, toastsToIgnore, questTypesToIgnore).withLatestVersion();
     }
 
     @Override
     public String toString() {
         return super.toString().replace("}", ", ") + String.format(
-                "fancyAdvancementToastsEnabled='%s', fancyQuestsToastsEnabled='%s', advancementToastsEnabled='%s', recipeToastsEnabled='%s', systemToastsEnabled='%s', tutorialToastsEnabled='%s', typesToIgnore='%s', toastsToIgnore='%s'}",
-                fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, toastsToIgnore
+                "fancyAdvancementToastsEnabled='%s', fancyQuestsToastsEnabled='%s', advancementToastsEnabled='%s', recipeToastsEnabled='%s', systemToastsEnabled='%s', tutorialToastsEnabled='%s', typesToIgnore='%s', questTypesToIgnore='%s', toastsToIgnore='%s'}",
+                fancyAdvancementToastsEnabled, fancyQuestToastsEnabled, advancementToastsEnabled, recipeToastsEnabled, systemToastsEnabled, tutorialToastsEnabled, typesToIgnore, questTypesToIgnore, toastsToIgnore
         );
     }
 }

--- a/common/src/main/java/net/bivrik/fancytoasts/client/gui/screen/ToastsFilteringScreen.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/gui/screen/ToastsFilteringScreen.java
@@ -1,8 +1,22 @@
 package net.bivrik.fancytoasts.client.gui.screen;
 
+import static net.bivrik.fancytoasts.client.gui.LayoutValues.BUTTON_HEIGHT;
+import static net.bivrik.fancytoasts.client.gui.LayoutValues.BUTTON_WIDTH;
+import static net.bivrik.fancytoasts.client.gui.LayoutValues.HALF_PADDING;
+import static net.bivrik.fancytoasts.client.gui.LayoutValues.MARGIN;
+import static net.bivrik.fancytoasts.client.gui.LayoutValues.PADDING;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.mojang.blaze3d.systems.RenderSystem;
+
 import net.bivrik.fancytoasts.client.config.ConfigHandler;
 import net.bivrik.fancytoasts.client.config.data.ToastsFilteringData;
+import net.bivrik.fancytoasts.client.gui.LayoutValues;
 import net.bivrik.fancytoasts.client.toast.Appearance;
 import net.bivrik.fancytoasts.core.Constants;
 import net.bivrik.fancytoasts.core.Managers;
@@ -26,13 +40,6 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
-import static net.bivrik.fancytoasts.client.gui.LayoutValues.*;
 
 public class ToastsFilteringScreen extends UniversalScreen {
     private static final Component TITLE = Components.of("title.toasts_filtering");
@@ -178,6 +185,7 @@ public class ToastsFilteringScreen extends UniversalScreen {
 
     private void drawListBackground(GuiGraphics guiGraphics) {
         GuiContext context = new GuiContext(guiGraphics);
+        int MARGIN = LayoutValues.MARGIN;
         RenderSystem.enableBlend();
         context.drawGUITexture(LIST_BACKGROUND, 0, MARGIN, this.width, this.height - MARGIN * 2 - 2, TextureUV.ZERO, 32, 32);
         context.drawGUITexture(Screen.HEADER_SEPARATOR, 0, MARGIN, this.width, 2, TextureUV.ZERO, 32, 2);

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/FancyAdvancementToast.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/FancyAdvancementToast.java
@@ -39,20 +39,38 @@ public class FancyAdvancementToast {
 
         AnimationSetup setup = new AnimationSetup(textureId, displayInfo, null, DefaultUVs.BACKGROUND, DefaultUVs.PLAQUE);
 
-        switch (displayInfo.getAdvancementType()) {
-            case TASK -> {
-                setup.setTypeBasedUVs(DefaultUVs.TASK);
-                volume = generalConfig.getTaskVolume();
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo qdi) {
+            switch (qdi.getQuestType()) {
+                case TASK, QUEST -> {
+                    setup.setTypeBasedUVs(DefaultUVs.TASK);
+                    volume = generalConfig.getTaskVolume();
+                }
+                case CHAPTER -> {
+                    setup.setTypeBasedUVs(DefaultUVs.GOAL);
+                    volume = generalConfig.getGoalVolume();
+                }
+                case BOOK -> {
+                    setup.setTypeBasedUVs(DefaultUVs.CHALLENGE);
+                    volume = generalConfig.getChallengeVolume();
+                }
+                default -> throw new RuntimeException("Could match correct quest type");
             }
-            case GOAL -> {
-                setup.setTypeBasedUVs(DefaultUVs.GOAL);
-                volume = generalConfig.getGoalVolume();
+        } else {
+            switch (displayInfo.getAdvancementType()) {
+                case TASK -> {
+                    setup.setTypeBasedUVs(DefaultUVs.TASK);
+                    volume = generalConfig.getTaskVolume();
+                }
+                case GOAL -> {
+                    setup.setTypeBasedUVs(DefaultUVs.GOAL);
+                    volume = generalConfig.getGoalVolume();
+                }
+                case CHALLENGE -> {
+                    setup.setTypeBasedUVs(DefaultUVs.CHALLENGE);
+                    volume = generalConfig.getChallengeVolume();
+                }
+                default -> throw new RuntimeException("Could match correct advancement type");
             }
-            case CHALLENGE -> {
-                setup.setTypeBasedUVs(DefaultUVs.CHALLENGE);
-                volume = generalConfig.getChallengeVolume();
-            }
-            default -> throw new RuntimeException("Could match correct advancement type");
         }
 
         animation = AnimationRegistry.getAnimation(animationId).get();

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/FancyAdvancementToast.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/FancyAdvancementToast.java
@@ -1,10 +1,11 @@
 package net.bivrik.fancytoasts.client.toast;
 
-import net.bivrik.fancytoasts.core.Debug;
+import java.util.Random;
+
 import net.bivrik.fancytoasts.client.registry.AnimationRegistry;
 import net.bivrik.fancytoasts.client.toast.animation.FancyToastAnimation;
+import net.bivrik.fancytoasts.core.Debug;
 import net.bivrik.fancytoasts.core.Managers;
-import net.bivrik.fancytoasts.core.manager.CustomTextureManager;
 import net.bivrik.fancytoasts.platform.utility.ToastDisplayInfo;
 import net.bivrik.fancytoasts.utility.DefaultUVs;
 import net.minecraft.client.Minecraft;
@@ -14,9 +15,6 @@ import net.minecraft.client.sounds.SoundManager;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
-
-import java.util.Optional;
-import java.util.Random;
 
 public class FancyAdvancementToast {
     private static final int WIDTH = 162;
@@ -59,7 +57,12 @@ public class FancyAdvancementToast {
 
         animation = AnimationRegistry.getAnimation(animationId).get();
         animation.setup(setup, minecraft, getWidth(), getHeight());
-        toastSoundId = Managers.getConfigManager().getToastConfigData().getSoundIdByType(displayInfo.getAdvancementType());
+
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo qdi) {
+            toastSoundId = Managers.getConfigManager().getToastConfigData().getSoundIdByQuestType(qdi.getQuestType());
+        } else {
+            toastSoundId = Managers.getConfigManager().getToastConfigData().getSoundIdByType(displayInfo.getAdvancementType());
+        }
 
         Debug.info("Created new fancy advancement toast: {}; texture: {}; animation: {}", displayInfo.getTitle().getString(), textureId, animationId);
     }

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/FancyToastAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/FancyToastAnimation.java
@@ -1,24 +1,23 @@
 package net.bivrik.fancytoasts.client.toast.animation;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
 import net.bivrik.fancytoasts.client.config.ToastScreenBehavior;
 import net.bivrik.fancytoasts.client.toast.AnimationSetup;
-import net.bivrik.fancytoasts.core.Debug;
-import net.bivrik.fancytoasts.core.event.GeneralConfigDataEvent;
-import net.bivrik.fancytoasts.utility.TypeBasedUVs;
 import net.bivrik.fancytoasts.core.Managers;
-import net.bivrik.fancytoasts.platform.utility.ToastDisplayInfo;
-import net.bivrik.fancytoasts.utility.TextureUV;
+import net.bivrik.fancytoasts.core.event.GeneralConfigDataEvent;
 import net.bivrik.fancytoasts.platform.utility.Colors;
 import net.bivrik.fancytoasts.platform.utility.GuiContext;
+import net.bivrik.fancytoasts.platform.utility.ToastDisplayInfo;
+import net.bivrik.fancytoasts.utility.TextureUV;
+import net.bivrik.fancytoasts.utility.TypeBasedUVs;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.FormattedCharSequence;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Consumer;
 
 public abstract class FancyToastAnimation {
     private final Consumer<GeneralConfigDataEvent> generalConfigDataEventConsumer;
@@ -129,7 +128,7 @@ public abstract class FancyToastAnimation {
         }
 
         int toastCenterX = toastWidth / 2;
-        int titleColor = Colors.alpha(alpha, displayInfo.getAdvancementType().getMainColor());
+        int titleColor = getMainColorAlpha(alpha);
         FormattedCharSequence titleLine = titleLines.getFirst();
 
         if (titleLines.size() == 1) {
@@ -148,7 +147,7 @@ public abstract class FancyToastAnimation {
             return;
         }
 
-        int descriptionColor = Colors.alpha(alpha, displayInfo.getAdvancementType().getSecondaryColor());
+        int descriptionColor = getSecondaryColorAlpha(alpha);
 
         guiGraphics.drawString(minecraft.font, descriptionLines.get(0), 8, 38, descriptionColor);
         if (descriptionLines.size() > 1) {
@@ -178,5 +177,21 @@ public abstract class FancyToastAnimation {
 
     protected int getColor(float alpha) {
         return Colors.alpha(guiAlpha * alpha, Colors.WHITE);
+    }
+
+    protected int getMainColorAlpha(float alpha) {
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo qdi) {
+            return Colors.alpha(alpha, qdi.getQuestType().getMainColor());
+        }
+
+        return Colors.alpha(alpha, displayInfo.getAdvancementType().getMainColor());
+    }
+
+    protected int getSecondaryColorAlpha(float alpha) {
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo qdi) {
+            return Colors.alpha(alpha, qdi.getQuestType().getSecondaryColor());
+        }
+
+        return Colors.alpha(alpha, displayInfo.getAdvancementType().getSecondaryColor());
     }
 }

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/OldlikeAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/OldlikeAnimation.java
@@ -21,7 +21,11 @@ public class OldlikeAnimation extends FancyToastAnimation {
     public void setup(AnimationSetup setup, Minecraft minecraft, int toastWidth, int toastHeight) {
         super.setup(setup, minecraft, toastWidth, toastHeight);
 
-        this.setLines(displayInfo.getAnnouncement(), displayInfo.getDescription());
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo) {
+            this.setLines(displayInfo.getAnnouncement(), displayInfo.getTitle());
+        } else {
+            this.setLines(displayInfo.getAnnouncement(), displayInfo.getDescription());
+        }
     }
 
     @Override

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/PlayfulAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/PlayfulAnimation.java
@@ -21,7 +21,11 @@ public class PlayfulAnimation extends FancyToastAnimation {
     public void setup(AnimationSetup setup, Minecraft minecraft, int toastWidth, int toastHeight) {
         super.setup(setup, minecraft, toastWidth, toastHeight);
 
-        this.setLines(displayInfo.getTitle(), displayInfo.getDescription());
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo) {
+            this.setLines(displayInfo.getAnnouncement(), displayInfo.getTitle());
+        } else {
+            this.setLines(displayInfo.getTitle(), displayInfo.getDescription());
+        }
     }
 
     @Override

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/QuirkyAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/QuirkyAnimation.java
@@ -25,7 +25,11 @@ public class QuirkyAnimation extends FancyToastAnimation {
     public void setup(AnimationSetup setup, Minecraft minecraft, int toastWidth, int toastHeight) {
         super.setup(setup, minecraft, toastWidth, toastHeight);
 
-        this.setLines(displayInfo.getAnnouncement(), displayInfo.getDescription());
+        if (displayInfo instanceof net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo) {
+            this.setLines(displayInfo.getAnnouncement(), displayInfo.getTitle());
+        } else {
+            this.setLines(displayInfo.getAnnouncement(), displayInfo.getDescription());
+        }
         randomRotation = new Random().nextFloat(-0.4f, 0.4f);
     }
 

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/QuirkyAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/QuirkyAnimation.java
@@ -1,13 +1,13 @@
 package net.bivrik.fancytoasts.client.toast.animation;
 
+import java.util.Random;
+
 import net.bivrik.fancytoasts.client.toast.AnimationSetup;
 import net.bivrik.fancytoasts.client.toast.Appearance;
-import net.bivrik.fancytoasts.platform.utility.Colors;
 import net.bivrik.fancytoasts.platform.utility.GuiContext;
 import net.bivrik.fancytoasts.utility.MathEasing;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import java.util.Random;
 
 public class QuirkyAnimation extends FancyToastAnimation {
     private final Appearance ICON_APPEARANCE = new Appearance(2000, 0);
@@ -115,7 +115,7 @@ public class QuirkyAnimation extends FancyToastAnimation {
         }
 
         int centerToastX = toastWidth / 2;
-        int descriptionColor = Colors.alpha(alpha, displayInfo.getAdvancementType().getSecondaryColor());
+        int descriptionColor = getSecondaryColorAlpha(alpha);
 
         guiGraphics.drawCenteredString(minecraft.font, descriptionLines.get(0), centerToastX, 38, descriptionColor);
         if (descriptionLines.size() > 1) {

--- a/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/StandardAnimation.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/client/toast/animation/StandardAnimation.java
@@ -2,7 +2,6 @@ package net.bivrik.fancytoasts.client.toast.animation;
 
 import net.bivrik.fancytoasts.client.toast.AnimationSetup;
 import net.bivrik.fancytoasts.client.toast.Appearance;
-import net.bivrik.fancytoasts.platform.utility.Colors;
 import net.bivrik.fancytoasts.platform.utility.GuiContext;
 import net.bivrik.fancytoasts.utility.MathEasing;
 import net.minecraft.client.Minecraft;
@@ -97,7 +96,7 @@ public class StandardAnimation extends FancyToastAnimation {
         }
 
         int centerToastX = this.toastWidth / 2;
-        int descriptionColor = Colors.alpha(alpha, this.displayInfo.getAdvancementType().getSecondaryColor());
+        int descriptionColor = getSecondaryColorAlpha(alpha);
 
         if (descriptionLines.size() == 1) {
             guiGraphics.drawCenteredString(this.minecraft.font, descriptionLines.getFirst(), centerToastX, 43, descriptionColor);

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
@@ -1,0 +1,44 @@
+package net.bivrik.fancytoasts.platform.utility;
+
+import net.minecraft.network.chat.Component;
+
+public enum FancyQuestType {
+    TASK("task", Colors.YELLOW, Colors.WHITE),
+    QUEST("quest", Colors.CYAN, Colors.WHITE),
+    CHAPTER("chapter", Colors.PURPLE, Colors.CYAN),
+    BOOK("file", Colors.BLACK, Colors.YELLOW);
+
+    private final String name;
+    private final int mainColor;
+    private final int secondaryColor;
+    private final Component displayName;
+    private final Component displayAnnouncement;
+
+    FancyQuestType(String name, int mainColor, int secondaryColor) {
+        this.name = name;
+        this.mainColor = mainColor;
+        this.secondaryColor = secondaryColor;
+        this.displayName = Components.of("quest_type." + this.name);
+        this.displayAnnouncement = Component.translatable("ftbquests." + this.name);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Component getDisplayName() {
+        return displayName;
+    }
+
+    public Component getDisplayAnnouncement() {
+        return displayAnnouncement;
+    }
+
+    public int getMainColor() {
+        return mainColor;
+    }
+
+    public int getSecondaryColor() {
+        return secondaryColor;
+    }
+}

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
@@ -5,8 +5,8 @@ import net.minecraft.network.chat.Component;
 public enum FancyQuestType {
     TASK("task", Colors.YELLOW, Colors.WHITE),
     QUEST("quest", Colors.CYAN, Colors.WHITE),
-    CHAPTER("chapter", Colors.PURPLE, Colors.CYAN),
-    BOOK("file", Colors.PURPLE, Colors.CYAN);
+    CHAPTER("chapter", Colors.CYAN, Colors.WHITE),
+    BOOK("file", Colors.PURPLE, Colors.WHITE);
 
     private final String name;
     private final int mainColor;

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/FancyQuestType.java
@@ -6,7 +6,7 @@ public enum FancyQuestType {
     TASK("task", Colors.YELLOW, Colors.WHITE),
     QUEST("quest", Colors.CYAN, Colors.WHITE),
     CHAPTER("chapter", Colors.PURPLE, Colors.CYAN),
-    BOOK("file", Colors.BLACK, Colors.YELLOW);
+    BOOK("file", Colors.PURPLE, Colors.CYAN);
 
     private final String name;
     private final int mainColor;

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/QuestToastDisplayInfo.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/QuestToastDisplayInfo.java
@@ -1,24 +1,30 @@
 package net.bivrik.fancytoasts.platform.utility;
 
+import java.util.List;
+
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
-
-import java.util.List;
 
 public class QuestToastDisplayInfo extends ToastDisplayInfo {
     private final Component announcementDisplay;
     private final List<ItemStack> icons;
+    private final FancyQuestType questType;
 
-    public QuestToastDisplayInfo(List<ItemStack> icons, Component title, Component description, FancyToastType advancementType, Component announcementDisplay) {
+    public QuestToastDisplayInfo(List<ItemStack> icons, Component title, Component description, FancyToastType advancementType, Component announcementDisplay, FancyQuestType questType) {
         super(null, title, description, advancementType);
 
         this.announcementDisplay = announcementDisplay;
         this.icons = icons;
+        this.questType = questType;
     }
 
     @Override
     public Component getAnnouncement() {
         return announcementDisplay;
+    }
+
+    public FancyQuestType getQuestType() {
+        return questType;
     }
 
     @Override

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
@@ -1,5 +1,7 @@
 package net.bivrik.fancytoasts.platform.utility;
 
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
 import net.bivrik.fancytoasts.client.config.data.ToastsFilteringData;
 import net.bivrik.fancytoasts.client.toast.IAdvancementAccessor;
 import net.bivrik.fancytoasts.core.manager.ToastManager;
@@ -8,7 +10,6 @@ import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.DisplayInfo;
 import net.minecraft.client.gui.components.toasts.AdvancementToast;
 import net.minecraft.client.gui.components.toasts.Toast;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 public record ToastsHandler(ToastsFilteringData filteringData, ToastManager toastManager, CallbackInfo info) {
 
@@ -40,12 +41,22 @@ public record ToastsHandler(ToastsFilteringData filteringData, ToastManager toas
     }
 
     public void handleFTBQuestsToasts(Toast toast) {
-        if (filteringData.isFancyQuestToastsEnabled()) {
-            info.cancel();
-
-            ToastDisplayInfo displayInfo = Services.FTB_QUESTS.getDisplayInfo(toast);
-            toastManager.addToast(displayInfo);
+        if (!filteringData.isFancyQuestToastsEnabled()) {
+            return;
         }
+        
+        ToastDisplayInfo displayInfo = Services.FTB_QUESTS.getDisplayInfo(toast);
+        String announcement = displayInfo.getAnnouncement().toString();
+        if (!announcement.startsWith("translation")) return;
+        String key = extractKey(announcement);
+        
+        boolean isTask = key.startsWith("ftbquests.task");
+        boolean isQuest = key.startsWith("ftbquests.quest");
+        boolean isChapter = key.startsWith("ftbquests.chapter");
+        boolean isBook = key.startsWith("ftbquests.file");
+
+        info.cancel();
+        toastManager.addToast(displayInfo);
     }
 
     public void handleRecipeToasts() {
@@ -64,5 +75,18 @@ public record ToastsHandler(ToastsFilteringData filteringData, ToastManager toas
         if (!filteringData.isTutorialToastsEnabled()) {
             info.cancel();
         }
+    }
+
+    public static String extractKey(String s)
+    {
+        String marker = "key='";
+        int startIndex = s.indexOf(marker);
+        if (startIndex == -1) return null;
+
+        startIndex += marker.length();
+        int endIndex = s.indexOf("\'", startIndex);
+        if (endIndex == -1) return null;
+
+        return s.substring(startIndex, endIndex);
     }
 }

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
@@ -46,17 +46,21 @@ public record ToastsHandler(ToastsFilteringData filteringData, ToastManager toas
         }
         
         ToastDisplayInfo displayInfo = Services.FTB_QUESTS.getDisplayInfo(toast);
-        String announcement = displayInfo.getAnnouncement().toString();
-        if (!announcement.startsWith("translation")) return;
-        String key = extractKey(announcement);
-        
-        if (key == null) return;
+        if (displayInfo == null) return;
 
         FancyQuestType questType = null;
-        for (FancyQuestType fq : FancyQuestType.values()) {
-            if (key.startsWith("ftbquests." + fq.getName())) {
-                questType = fq;
-                break;
+        if (displayInfo instanceof QuestToastDisplayInfo qdi) {
+            questType = qdi.getQuestType();
+        } else {
+            String announcement = displayInfo.getAnnouncement().toString();
+            if (!announcement.startsWith("translation")) return;
+            String key = extractKey(announcement);
+            if (key == null) return;
+            for (FancyQuestType fq : FancyQuestType.values()) {
+                if (key.startsWith("ftbquests." + fq.getName())) {
+                    questType = fq;
+                    break;
+                }
             }
         }
 

--- a/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
+++ b/common/src/main/java/net/bivrik/fancytoasts/platform/utility/ToastsHandler.java
@@ -50,10 +50,17 @@ public record ToastsHandler(ToastsFilteringData filteringData, ToastManager toas
         if (!announcement.startsWith("translation")) return;
         String key = extractKey(announcement);
         
-        boolean isTask = key.startsWith("ftbquests.task");
-        boolean isQuest = key.startsWith("ftbquests.quest");
-        boolean isChapter = key.startsWith("ftbquests.chapter");
-        boolean isBook = key.startsWith("ftbquests.file");
+        if (key == null) return;
+
+        FancyQuestType questType = null;
+        for (FancyQuestType fq : FancyQuestType.values()) {
+            if (key.startsWith("ftbquests." + fq.getName())) {
+                questType = fq;
+                break;
+            }
+        }
+
+        if (questType != null && filteringData.isQuestTypeIgnored(questType)) return; // If ignored, do nothing
 
         info.cancel();
         toastManager.addToast(displayInfo);

--- a/fabric/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
+++ b/fabric/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
@@ -2,6 +2,8 @@ package net.bivrik.fancytoasts.compat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import dev.ftb.mods.ftblibrary.icon.Icon;
 import dev.ftb.mods.ftblibrary.icon.IconAnimation;
@@ -103,6 +105,17 @@ public class FTBQuestsCompat {
             }
         }
 
-        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement, questType);
+        // If a QUEST toast has a subtitle, swap display lines instead of 'Quest Completed'
+        Component announcementDisplay = questAnnouncement;
+        Component titleDisplay = title;
+        if (questType == FancyQuestType.QUEST && quest != null) {
+            Component questSubtitle = quest.getSubtitle();
+            if (questSubtitle != null && !questSubtitle.getString().isEmpty()) {
+                announcementDisplay = title; // quest title becomes main line
+                titleDisplay = questSubtitle; // quest subtitle becomes secondary line
+            }
+        }
+
+        return new QuestToastDisplayInfo(icons, titleDisplay, description, toastType, announcementDisplay, questType);
     }
 }

--- a/fabric/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
+++ b/fabric/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
@@ -1,5 +1,8 @@
 package net.bivrik.fancytoasts.compat;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 import dev.ftb.mods.ftblibrary.icon.Icon;
 import dev.ftb.mods.ftblibrary.icon.IconAnimation;
 import dev.ftb.mods.ftblibrary.icon.ItemIcon;
@@ -9,16 +12,16 @@ import dev.ftb.mods.ftbquests.quest.Quest;
 import dev.ftb.mods.ftbquests.quest.QuestObjectBase;
 import dev.ftb.mods.ftbquests.registry.ModItems;
 import net.bivrik.fancytoasts.core.Constants;
+import net.bivrik.fancytoasts.platform.utility.FancyQuestType;
 import net.bivrik.fancytoasts.platform.utility.FancyToastType;
 import net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo;
 import net.bivrik.fancytoasts.platform.utility.ResourceLocations;
 import net.bivrik.fancytoasts.platform.utility.ToastDisplayInfo;
+import net.bivrik.fancytoasts.platform.utility.ToastsHandler;
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-
-import java.util.*;
 
 public class FTBQuestsCompat {
     private static final Map<Long, Long> REPEATABLE_QUESTS = new HashMap<>(3);
@@ -87,6 +90,19 @@ public class FTBQuestsCompat {
             }
         }
 
-        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement);
+        // Try to extract quest-type key from the announcement component (falls back to TASK)
+        FancyQuestType questType = FancyQuestType.TASK;
+        String ann = questAnnouncement.toString();
+        String key = ToastsHandler.extractKey(ann);
+        if (key != null) {
+            for (FancyQuestType fq : FancyQuestType.values()) {
+                if (key.startsWith("ftbquests." + fq.getName())) {
+                    questType = fq;
+                    break;
+                }
+            }
+        }
+
+        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement, questType);
     }
 }

--- a/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
+++ b/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
@@ -106,16 +106,12 @@ public class FTBQuestsCompat {
         }
 
         // If a QUEST toast has a subtitle, swap display lines instead of 'Quest Completed'
-        Component announcementDisplay = questAnnouncement;
-        Component titleDisplay = title;
         if (questType == FancyQuestType.QUEST && quest != null) {
             Component questSubtitle = quest.getSubtitle();
             if (questSubtitle != null && !questSubtitle.getString().isEmpty()) {
-                announcementDisplay = title; // quest title becomes main line
-                titleDisplay = questSubtitle; // quest subtitle becomes secondary line
+                return new QuestToastDisplayInfo(icons, questSubtitle, description, toastType, title, questType);
             }
         }
-
-        return new QuestToastDisplayInfo(icons, titleDisplay, description, toastType, announcementDisplay, questType);
+        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement, questType);
     }
 }

--- a/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
+++ b/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
@@ -105,6 +105,17 @@ public class FTBQuestsCompat {
             }
         }
 
-        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement, questType);
+        // If a QUEST toast has a subtitle, swap display lines instead of 'Quest Completed'
+        Component announcementDisplay = questAnnouncement;
+        Component titleDisplay = title;
+        if (questType == FancyQuestType.QUEST && quest != null) {
+            Component questSubtitle = quest.getSubtitle();
+            if (questSubtitle != null && !questSubtitle.getString().isEmpty()) {
+                announcementDisplay = title; // quest title becomes main line
+                titleDisplay = questSubtitle; // quest subtitle becomes secondary line
+            }
+        }
+
+        return new QuestToastDisplayInfo(icons, titleDisplay, description, toastType, announcementDisplay, questType);
     }
 }

--- a/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
+++ b/neoforge/src/main/java/net/bivrik/fancytoasts/compat/FTBQuestsCompat.java
@@ -1,5 +1,10 @@
 package net.bivrik.fancytoasts.compat;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import dev.ftb.mods.ftblibrary.icon.Icon;
 import dev.ftb.mods.ftblibrary.icon.IconAnimation;
 import dev.ftb.mods.ftblibrary.icon.ItemIcon;
@@ -9,16 +14,16 @@ import dev.ftb.mods.ftbquests.quest.Quest;
 import dev.ftb.mods.ftbquests.quest.QuestObjectBase;
 import dev.ftb.mods.ftbquests.registry.ModItems;
 import net.bivrik.fancytoasts.core.Constants;
+import net.bivrik.fancytoasts.platform.utility.FancyQuestType;
 import net.bivrik.fancytoasts.platform.utility.FancyToastType;
 import net.bivrik.fancytoasts.platform.utility.QuestToastDisplayInfo;
 import net.bivrik.fancytoasts.platform.utility.ResourceLocations;
 import net.bivrik.fancytoasts.platform.utility.ToastDisplayInfo;
+import net.bivrik.fancytoasts.platform.utility.ToastsHandler;
 import net.minecraft.client.gui.components.toasts.Toast;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-
-import java.util.*;
 
 public class FTBQuestsCompat {
     private static final Map<Long, Long> REPEATABLE_QUESTS = new HashMap<>(3);
@@ -87,6 +92,19 @@ public class FTBQuestsCompat {
             }
         }
 
-        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement);
+        // Try to extract quest-type key from the announcement component (falls back to TASK)
+        FancyQuestType questType = FancyQuestType.TASK;
+        String ann = questAnnouncement.toString();
+        String key = ToastsHandler.extractKey(ann);
+        if (key != null) {
+            for (FancyQuestType fq : FancyQuestType.values()) {
+                if (key.startsWith("ftbquests." + fq.getName())) {
+                    questType = fq;
+                    break;
+                }
+            }
+        }
+
+        return new QuestToastDisplayInfo(icons, title, description, toastType, questAnnouncement, questType);
     }
 }


### PR DESCRIPTION
Resolves #51 

## Description
Allows for the user to have finer control over how FTB Quests toasts are displays, handling them separately from vanilla advancements.

Primarily, this adds `questTypesToIgnore` in the toast_filtering JSON. These allow the user to individually enable/disable the four types of FTB Quest toasts available.
```
  "questTypesToIgnore": {
    "TASK": false,
    "QUEST": false,
    "CHAPTER": false,
    "BOOK": false
  },
```
Like `typesToIgnore`, these are only editable in the config file, not the in-game config menu.
(`"BOOK"` is for the toast that shows when the user has fully completed the quest book)


## Example Videos

### Toast Filtering
TASK quest handling specifically disabled, reverting those to FTB Quests' standard toasts.

https://github.com/user-attachments/assets/c1b5a59c-4a15-4558-975b-29038270c1b5



### Quest Handling
Shows the different variants of toasts for FTB Quests.
Tasks & Quests use the 'task' textures, Chapters use the 'goal' textures, and Book uses the 'Challenge' textures.
Tasks utilize the ALLAY_ITEM_GIVEN sound for a more subtle notification.
Additionally, if a quest has a subtitle, it will use the quest title instead of 'Quest Completed' and put the quest subtitle in the toast subtitle.
(Videos sped up by 1.35x for timing)

https://github.com/user-attachments/assets/c9664352-1586-468d-ab36-e31cdef4b6d8

I'm fairly sure this is similar to the way quests were handled originally, so this is mostly to show I didn't deviate too far. Hopefully.