### PR TITLE
i18n: Update Simplified Chinese and Traditional Chinese translations to 1.4.7

### DIFF
--- a/common/src/main/resources/assets/fancytoasts/lang/zh_cn.json
+++ b/common/src/main/resources/assets/fancytoasts/lang/zh_cn.json
@@ -1,5 +1,5 @@
 {
-  // By Gao Xinyang (< 1.4.6)
+  // By Gao Xinyang
   "fancytoasts.title.visual_settings": "视觉设置",
   "fancytoasts.title.general_settings": "通用设置",
   "fancytoasts.title.toasts_filtering": "提示过滤设置",
@@ -27,10 +27,11 @@
   "fancytoasts.gui.config_folder": "配置文件夹",
   "fancytoasts.gui.reload_customs": "重新加载自定义内容",
   "fancytoasts.gui.reset": "重置",
-  "fancytoasts.gui.general_settings": "设置",
-  "fancytoasts.gui.toast_settings": "提示设置",
-  "fancytoasts.gui.toasts_filtering": "提示过滤设置",
+  "fancytoasts.gui.general_settings": "通用设置...",
+  "fancytoasts.gui.toast_settings": "视觉设置...",
+  "fancytoasts.gui.toasts_filtering": "提示过滤设置...",
   "fancytoasts.gui.jade_hiding": "提示显示时隐藏 Jade",
+  "fancytoasts.gui.boss_bar_hiding": "提示显示时隐藏 BOSS 栏",
   "fancytoasts.gui.sounds_enabled": "提示音效",
   "fancytoasts.gui.task_volume": "任务音量",
   "fancytoasts.gui.goal_volume": "目标音量",
@@ -38,9 +39,8 @@
   "fancytoasts.gui.screen_behavior": "界面渲染模式",
   "fancytoasts.gui.loops_strength": "波动强度",
   "fancytoasts.gui.loops_speed": "波动速度",
-  "fancytoasts.gui.boss_bar_hiding": "提示显示时隐藏首领血条", // Machine translation
-  "fancytoasts.gui.pitch_randomness": "音高随机变化", // Machine translation
-  "fancytoasts.gui.animation_speed": "动画速度", // Machine translation
+  "fancytoasts.gui.pitch_randomness": "音调随机度",
+  "fancytoasts.gui.animation_speed": "动画速度倍率",
   "fancytoasts.gui.anchor": "定位锚点",
   "fancytoasts.gui.fancy_advancement_toasts": "花式进度提示",
   "fancytoasts.gui.advancement_toasts": "进度提示",
@@ -49,8 +49,8 @@
   "fancytoasts.gui.system_toasts": "系统提示",
   "fancytoasts.gui.tutorial_toasts": "教程提示",
   "fancytoasts.gui.ignored_toasts": "已忽略的提示",
-  "fancytoasts.gui.title_display_text": "提示标题", // Machine translation
-  "fancytoasts.gui.description_display_text": "提示描述", // Machine translation
+  "fancytoasts.gui.title_display_text": "标题显示文本",
+  "fancytoasts.gui.description_display_text": "描述显示文本",
 
   "fancytoasts.toast_type.task": "任务",
   "fancytoasts.toast_type.goal": "目标",
@@ -60,10 +60,10 @@
   "fancytoasts.screen_behavior.behind": "置于界面后",
   "fancytoasts.screen_behavior.top": "置于界面上",
 
-  "fancytoasts.text_type.default": "默认", // Machine translation
-  "fancytoasts.text_type.title": "标题", // Machine translation
-  "fancytoasts.text_type.description": "描述", // Machine translation
-  "fancytoasts.text_type.announcement": "公告", // Machine translation
+  "fancytoasts.text_type.default": "默认",
+  "fancytoasts.text_type.title": "标题",
+  "fancytoasts.text_type.description": "描述",
+  "fancytoasts.text_type.announcement": "公告",
 
   "fancytoasts.anchor.top_left": "左上",
   "fancytoasts.anchor.top": "中上",
@@ -87,46 +87,46 @@
   "fancytoasts.tooltip.animations": "进度提示显示时使用的动画效果。",
   "fancytoasts.tooltip.sounds": "进度提示出现时播放的音效，根据进度类型而定。",
   "fancytoasts.tooltip.jade_hiding": "开关 Jade 隐藏功能。开启后，当进度提示出现时，Jade 信息牌会暂时隐藏，随后再次显示。",
+  "fancytoasts.tooltip.boss_bar_hiding": "开关 BOSS 栏隐藏功能。开启后，当进度提示出现时 BOSS 栏会隐藏，随后重新显示。",
   "fancytoasts.tooltip.sounds_enabled": "开关提示音效。关闭后，所有进度提示音效将被静音。",
   "fancytoasts.tooltip.anchor": "设置进度提示在屏幕上的定位锚点。坐标 “x” 和 “y” 是基于锚点的偏移量。",
   "fancytoasts.tooltip.screen_behavior": "设置打开界面（如背包、箱子等）时进度提示的渲染方式。",
   "fancytoasts.tooltip.reload_customs": "重新加载所有基于配置的文件（如材质），并更新上方列表中的内容。",
   "fancytoasts.tooltip.loops_strength": "控制正弦/余弦波的强度，数值越大波动越明显。",
   "fancytoasts.tooltip.loops_speed": "控制正弦/余弦波的速度，数值越大波动越快。",
-  "fancytoasts.tooltip.boss_bar_hiding": "切换首领血条隐藏功能。开启后，当进度提示出现时会隐藏首领血条，随后再重新显示。", // Machine translation
-  "fancytoasts.tooltip.pitch_randomness": "播放音效时应用音高随机变化以避免重复单调。0% = 完全无音高变化。", // Machine translation
-  "fancytoasts.tooltip.animation_speed": "作为动画速度的倍率系数。", // Machine translation
+  "fancytoasts.tooltip.pitch_randomness": "播放音效时应用音调随机变化，避免过于重复。0% 表示无音调变化。",
+  "fancytoasts.tooltip.animation_speed": "控制动画速度的倍率系数。",
   "fancytoasts.tooltip.toasts_filtering": "需要重启 Minecraft 生效。若要屏蔽单个进度，请在 'toastsToIgnore' 中输入 “命名空间:类别/进度”。若要屏蔽整个类别，请输入 “命名空间:类别/...”。",
-  "fancytoasts.tooltip.display_text.default": "将动画中的默认预设显示为提示的标题/描述。", // Machine translation
-  "fancytoasts.tooltip.display_text.title": "将进度的标题显示为提示的标题/描述。", // Machine translation
-  "fancytoasts.tooltip.display_text.description": "将进度的描述显示为提示的标题/描述。", // Machine translation
-  "fancytoasts.tooltip.display_text.announcement": "将进度的公告显示为提示的标题/描述。", // Machine translation
+  "fancytoasts.tooltip.display_text.default": "将动画中的默认预设显示为提示的标题或描述。",
+  "fancytoasts.tooltip.display_text.title": "将进度的标题显示为提示的标题或描述。",
+  "fancytoasts.tooltip.display_text.description": "将进度的描述显示为提示的标题或描述。",
+  "fancytoasts.tooltip.display_text.announcement": "将进度的公告显示为提示的标题或描述。",
 
   "fancytoasts.toast.animation.standard": "标准",
-  "fancytoasts.toast.animation.standard.description": "标准动画。平稳流畅，自上而下轻柔滑动。略带原版风格。",
+  "fancytoasts.toast.animation.standard.description": "标准感，沉稳平静。图标先行，自上而下轻柔滑入。略带原版风格。",
   "fancytoasts.toast.animation.playful": "活泼",
-  "fancytoasts.toast.animation.playful.description": "活力四射！趣味十足！游戏感满满！充满能量且更具实验性的动画，带有旋转效果。",
+  "fancytoasts.toast.animation.playful.description": "活力迸发！趣味十足！满满游戏感！能量十足且更具实验性的动画，还带着几分旋转跳跃。",
   "fancytoasts.toast.animation.quirky": "搞怪",
-  "fancytoasts.toast.animation.quirky.description": "摇摆不定，充满野性。持续运动，永不停歇——不过看久了可能会眼花哦。",
+  "fancytoasts.toast.animation.quirky.description": "摇摇晃晃，野性难驯。一刻不停歇，永远在动——小心看久了会头晕哦～",
   "fancytoasts.toast.animation.oldlike": "怀旧风格",
-  "fancytoasts.toast.animation.oldlike.description": "今天想来点复古风味？灵感来源于经典的进度提示。从右向左滑动，带有透明浮现效果。",
+  "fancytoasts.toast.animation.oldlike.description": "今天想玩点优雅范儿？灵感源自经典的老式进度提示。从右向左滑入，伴有透明渐显效果。",
 
   "fancytoasts.toast.texture.vanilla": "原版风格",
-  "fancytoasts.toast.texture.vanilla.description": "灵感源自 Minecraft 原版风格。",
+  "fancytoasts.toast.texture.vanilla.description": "灵感源自 Minecraft 原版风格，朴素亲切。",
   "fancytoasts.toast.texture.nature": "自然",
-  "fancytoasts.toast.texture.nature.description": "彷徨于林间某处。灵感源自我们的大自然母亲，仿佛用树枝与其他自然材料制成。",
+  "fancytoasts.toast.texture.nature.description": "迷失在林间深处。材质仿佛用树枝……和其他天然材料拼成。致敬我们的大自然母亲。",
   "fancytoasts.toast.texture.og": "怀旧经典",
-  "fancytoasts.toast.texture.og.description": "如果你是真正的老派玩家，并且喜爱古老粗犷的风格，那么这个正适合你。毫无花哨！",
+  "fancytoasts.toast.texture.og.description": "如果你是真正的 OG 玩家，钟爱古老粗犷的风格，那这个正合你意。毫无花哨，原汁原味！",
   "fancytoasts.toast.texture.modern": "现代",
-  "fancytoasts.toast.texture.modern.description": "精美、简洁、利落。",
+  "fancytoasts.toast.texture.modern.description": "精致、简洁、利落，现代极简之美。",
   "fancytoasts.toast.texture.terracraft": "泰拉工艺",
-  "fancytoasts.toast.texture.terracraft.description": "那是什么？我想我看到了天空中有一只巨大的红眼！哦，等等，它冲过来了……灵感源自《泰拉瑞亚》。",
+  "fancytoasts.toast.texture.terracraft.description": "那是什么？天空中好像有一只巨大的红眼！等等，它冲过来了……灵感源自《泰拉瑞亚》。",
   "fancytoasts.toast.texture.steamy": "Steam 风格",
-  "fancytoasts.toast.texture.steamy.description": "我花了 1500 小时才达成 100% 完成度！妈妈你为我骄傲吗？灵感源自 Steam。",
+  "fancytoasts.toast.texture.steamy.description": "我花了 1500 小时才达成 100% 全成就！妈妈你为我骄傲吗？妈妈？！灵感源自 Steam。",
   "fancytoasts.toast.texture.landspaper": "信件壁纸",
-  "fancytoasts.toast.texture.landspaper.description": "你收到了一封新信！不妨把它钉在某个地方以便仔细阅读。希望它不会受潮溶解。",
-  "fancytoasts.toast.texture.neon": "霓虹", // Machine translation
-  "fancytoasts.toast.texture.neon.description": "想要些暗色调氛围？霓虹灯牌在夜间可是非常吸引人的", // Machine translation
+  "fancytoasts.toast.texture.landspaper.description": "好像来了一封新信！不妨把它钉在墙上仔细端详。但愿它不会受潮化掉。",
+  "fancytoasts.toast.texture.neon": "霓虹",
+  "fancytoasts.toast.texture.neon.description": "喜欢暗黑氛围？霓虹灯牌在夜里可是格外迷人哦。",
 
   "fancytoasts.toast.sound.minecraft.description": "Minecraft 内置音效",
   "fancytoasts.toast.sound.mod.description": "来自模组的音效",

--- a/common/src/main/resources/assets/fancytoasts/lang/zh_tw.json
+++ b/common/src/main/resources/assets/fancytoasts/lang/zh_tw.json
@@ -1,106 +1,106 @@
 {
-  // By ChaTian (< 1.4.4)
-  "fancytoasts.title.visual_settings": "自訂設定",
+  // By ChaTian & Gao Xinyang
+  "fancytoasts.title.visual_settings": "視覺設定",
   "fancytoasts.title.general_settings": "一般設定",
-  "fancytoasts.title.toasts_filtering": "提示過濾", // Machine translation
-  "fancytoasts.title.reset_general_settings": "重置常規設定", // Machine translation
-  "fancytoasts.title.reset_toasts_filtering": "重置提示篩選", // Machine translation
+  "fancytoasts.title.toasts_filtering": "提示過濾設定",
+  "fancytoasts.title.reset_general_settings": "重設一般設定",
+  "fancytoasts.title.reset_toasts_filtering": "重設提示過濾設定",
 
-  "fancytoasts.label.support": "快來看看我在Boosty上的部落格吧！",
+  "fancytoasts.label.support": "快來看看我在 Boosty 上的部落格！",
   "fancytoasts.label.unknown": "未知",
   "fancytoasts.label.custom": "自訂",
-  "fancytoasts.label.reset_general_settings": "重設一般設定將會把所有現有設定清除並恢復為標準設定。你確定要這麼做嗎？", // Machine translation
-  "fancytoasts.label.reset_toasts_filtering": "重置提示訊息篩選條件會將所有現有篩選條件還原為預設值。您確定要這樣做嗎？", // Machine translation
+  "fancytoasts.label.reset_general_settings": "重設一般設定將會清除所有現有設定並恢復為預設值。確定要這麼做嗎？",
+  "fancytoasts.label.reset_toasts_filtering": "重設提示過濾設定將會清除所有現有過濾器並恢復為預設值。確定要這麼做嗎？",
   "fancytoasts.label.author": "作者：",
   "fancytoasts.label.description": "描述：",
-  "fancytoasts.label.translators": "翻譯人員", // Machine translation
-  "fancytoasts.label.github_activists": "Github 貢獻者", // Machine translation
-  "fancytoasts.label.boosters": "支持者", // Machine translation
-  "fancytoasts.label.special_thanks": "特別感謝", // Machine translation
-  "fancytoasts.label.credits_fallback": "無法加載鳴謝名單", // Machine translation
-  "fancytoasts.label.saved": "已儲存！", // Machine translation
+  "fancytoasts.label.translators": "翻譯人員",
+  "fancytoasts.label.github_activists": "GitHub 貢獻者",
+  "fancytoasts.label.boosters": "贊助者",
+  "fancytoasts.label.special_thanks": "特別感謝",
+  "fancytoasts.label.credits_fallback": "無法連線以載入鳴謝名單",
+  "fancytoasts.label.saved": "已儲存！",
 
   "fancytoasts.gui.textures": "材質",
   "fancytoasts.gui.animations": "動畫",
   "fancytoasts.gui.sounds": "音效",
-  "fancytoasts.gui.credits": "製作名單", // Machine translation
-  "fancytoasts.gui.config_folder": "設定資料夾", // Machine translation
-  "fancytoasts.gui.reload_customs": "重新載入自訂內容", // Machine translation
+  "fancytoasts.gui.credits": "鳴謝",
+  "fancytoasts.gui.config_folder": "設定資料夾",
+  "fancytoasts.gui.reload_customs": "重新載入自訂內容",
   "fancytoasts.gui.reset": "重設",
-  "fancytoasts.gui.general_settings": "設定",
-  "fancytoasts.gui.toast_settings": "提示設定",
-  "fancytoasts.gui.toasts_filtering": "Toasts 過濾", // Machine translation
-  "fancytoasts.gui.jade_hiding": "在提示時隱藏 Jade", // Machine translation
+  "fancytoasts.gui.general_settings": "一般設定...",
+  "fancytoasts.gui.toast_settings": "視覺設定...",
+  "fancytoasts.gui.toasts_filtering": "提示過濾設定...",
+  "fancytoasts.gui.jade_hiding": "提示顯示時隱藏 Jade",
+  "fancytoasts.gui.boss_bar_hiding": "提示顯示時隱藏 Boss 條",
   "fancytoasts.gui.sounds_enabled": "提示音效",
   "fancytoasts.gui.task_volume": "任務音量",
   "fancytoasts.gui.goal_volume": "目標音量",
   "fancytoasts.gui.challenge_volume": "挑戰音量",
-  "fancytoasts.gui.screen_behavior": "顯示方式",
-  "fancytoasts.gui.loops_strength": "循環強度", // Machine translation
-  "fancytoasts.gui.loops_speed": "循環速度", // Machine translation
-  "fancytoasts.gui.boss_bar_hiding": "提示顯示時隱藏首領血條", // Machine translation
-  "fancytoasts.gui.pitch_randomness": "音高隨機性", // Machine translation
-  "fancytoasts.gui.animation_speed": "動畫速度", // Machine translation
-  "fancytoasts.gui.anchor": "錨點", // Machine translation
-  "fancytoasts.gui.fancy_advancement_toasts": "華麗進度提示", // Machine translation
-  "fancytoasts.gui.advancement_toasts": "進度提示", // Machine translation
-  "fancytoasts.gui.fancy_quest_toasts": "華麗任務提示", // Machine translation
-  "fancytoasts.gui.recipe_toasts": "配方提示", // Machine translation
-  "fancytoasts.gui.system_toasts": "系統提示", // Machine translation
-  "fancytoasts.gui.tutorial_toasts": "教學提示", // Machine translation
-  "fancytoasts.gui.ignored_toasts": "忽略的提示", // Machine translation
-  "fancytoasts.gui.title_display_text": "提示標題", // Machine translation
-  "fancytoasts.gui.description_display_text": "提示描述", // Machine translation
+  "fancytoasts.gui.screen_behavior": "介面顯示模式",
+  "fancytoasts.gui.loops_strength": "波動強度",
+  "fancytoasts.gui.loops_speed": "波動速度",
+  "fancytoasts.gui.pitch_randomness": "音調隨機度",
+  "fancytoasts.gui.animation_speed": "動畫速度倍率",
+  "fancytoasts.gui.anchor": "定位錨點",
+  "fancytoasts.gui.fancy_advancement_toasts": "華麗進度提示",
+  "fancytoasts.gui.advancement_toasts": "進度提示",
+  "fancytoasts.gui.fancy_quest_toasts": "華麗任務提示",
+  "fancytoasts.gui.recipe_toasts": "配方提示",
+  "fancytoasts.gui.system_toasts": "系統提示",
+  "fancytoasts.gui.tutorial_toasts": "教學提示",
+  "fancytoasts.gui.ignored_toasts": "已忽略的提示",
+  "fancytoasts.gui.title_display_text": "標題顯示文字",
+  "fancytoasts.gui.description_display_text": "描述顯示文字",
 
   "fancytoasts.toast_type.task": "任務",
   "fancytoasts.toast_type.goal": "目標",
   "fancytoasts.toast_type.challenge": "挑戰",
 
   "fancytoasts.screen_behavior.transparent": "透明",
-  "fancytoasts.screen_behavior.behind": "在畫面後方",
-  "fancytoasts.screen_behavior.top": "上方",
+  "fancytoasts.screen_behavior.behind": "置於介面後",
+  "fancytoasts.screen_behavior.top": "置於介面上",
 
-  "fancytoasts.text_type.default": "預設", // Machine translation
-  "fancytoasts.text_type.title": "標題", // Machine translation
-  "fancytoasts.text_type.description": "描述", // Machine translation
-  "fancytoasts.text_type.announcement": "公告", // Machine translation
+  "fancytoasts.text_type.default": "預設",
+  "fancytoasts.text_type.title": "標題",
+  "fancytoasts.text_type.description": "描述",
+  "fancytoasts.text_type.announcement": "公告",
 
-  "fancytoasts.anchor.top_left": "左上", // Machine translation
-  "fancytoasts.anchor.top": "中上", // Machine translation
-  "fancytoasts.anchor.top_right": "右上", // Machine translation
-  "fancytoasts.anchor.center_left": "左中", // Machine translation
-  "fancytoasts.anchor.center": "中間", // Machine translation
-  "fancytoasts.anchor.center_right": "右中", // Machine translation
-  "fancytoasts.anchor.bottom_left": "左下", // Machine translation
-  "fancytoasts.anchor.bottom": "中下", // Machine translation
-  "fancytoasts.anchor.bottom_right": "右下", // Machine translation
+  "fancytoasts.anchor.top_left": "左上",
+  "fancytoasts.anchor.top": "中上",
+  "fancytoasts.anchor.top_right": "右上",
+  "fancytoasts.anchor.center_left": "左中",
+  "fancytoasts.anchor.center": "正中",
+  "fancytoasts.anchor.center_right": "右中",
+  "fancytoasts.anchor.bottom_left": "左下",
+  "fancytoasts.anchor.bottom": "中下",
+  "fancytoasts.anchor.bottom_right": "右下",
 
   "fancytoasts.filter.a_z": "A-Z",
   "fancytoasts.filter.z_a": "Z-A",
-  "fancytoasts.filter.built_in": "內建", // Machine translation
-  "fancytoasts.filter.custom": "自訂", // Machine translation
+  "fancytoasts.filter.built_in": "內建",
+  "fancytoasts.filter.custom": "自訂",
 
-  "fancytoasts.tooltip.task": "任務類進度的音效。",
-  "fancytoasts.tooltip.goal": "目標類進度的音效。",
-  "fancytoasts.tooltip.challenge": "挑戰類型進度的音效。",
-  "fancytoasts.tooltip.textures": "用於進度提示框的材質。自訂材質可從 \"./config/textures/\" 資料夾中載入。",
-  "fancytoasts.tooltip.animations": "提示框顯示時所使用的動畫。",
-  "fancytoasts.tooltip.sounds": "提示框出現時播放的音效。.",
-  "fancytoasts.tooltip.jade_hiding": "切換 Jade 隱藏。如果開啟，當進度提示出現時，Jade 的標記將會被隱藏，然後再重新顯示。", // Machine translation
-  "fancytoasts.tooltip.sounds_enabled": "切換音效。若關閉，所有提示音效將會靜音。",
-  "fancytoasts.tooltip.anchor": "代表進度提示在畫面上的錨點。位置 \"x\" 和 \"y\" 是根據錨點計算的偏移量。", // Machine translation
-  "fancytoasts.tooltip.screen_behavior": "設定當開啟介面（如背包、儲物箱等）時，進度提示的顯示方式。",
-  "fancytoasts.tooltip.reload_customs": "重新載入所有基於設定的檔案，例如材質，並在列表中新增/移除它們。", // Machine translation
-  "fancytoasts.tooltip.loops_strength": "代表正弦/餘弦波的強度，較弱/較強的波浪。", // Machine translation
-  "fancytoasts.tooltip.loops_speed": "代表正弦/餘弦波的速度，較慢/較快的波浪。", // Machine translation
-  "fancytoasts.tooltip.boss_bar_hiding": "切換是否隱藏首領血條。若開啟，當進度提示出現時，首領血條將會暫時隱藏，並在提示結束後重新顯示。", // Machine translation
-  "fancytoasts.tooltip.pitch_randomness": "播放音效時會應用音高隨機性，使其聽起來不那麼重複。0% = 完全無音高變化。", // Machine translation
-  "fancytoasts.tooltip.animation_speed": "作為動畫速度的倍率係數。", // Machine translation
-  "fancytoasts.tooltip.toasts_filtering": "需要重新啟動 Minecraft。要將單一進度加入黑名單，請在 'toastsToIgnore' 中輸入 \"namespace:category/advancement\"。要將整個類別加入黑名單，請輸入 \"namespace:category/...\"", // Machine translation
-  "fancytoasts.tooltip.display_text.default": "以動畫中的預設預設值作為提示的標題/描述顯示。", // Machine translation
-  "fancytoasts.tooltip.display_text.title": "以進度的標題作為提示的標題/描述顯示。", // Machine translation
-  "fancytoasts.tooltip.display_text.description": "以進度的描述作為提示的標題/描述顯示。", // Machine translation
-  "fancytoasts.tooltip.display_text.announcement": "以進度的公告作為提示的標題/描述顯示。", // Machine translation
+  "fancytoasts.tooltip.task": "任務類進度提示的出現音效。",
+  "fancytoasts.tooltip.goal": "目標類進度提示的出現音效。",
+  "fancytoasts.tooltip.challenge": "挑戰類進度提示的出現音效。",
+  "fancytoasts.tooltip.textures": "用於進度提示的材質樣式。自訂材質可從 \"./config/textures/\" 資料夾載入。",
+  "fancytoasts.tooltip.animations": "進度提示顯示時使用的動畫效果。",
+  "fancytoasts.tooltip.sounds": "進度提示出現時播放的音效，依進度類型而定。",
+  "fancytoasts.tooltip.jade_hiding": "切換 Jade 隱藏功能。開啟後，當進度提示出現時，Jade 資訊牌會暫時隱藏，隨後再次顯示。",
+  "fancytoasts.tooltip.boss_bar_hiding": "切換 Boss 條隱藏功能。開啟後，當進度提示出現時 Boss 條會隱藏，隨後重新顯示。",
+  "fancytoasts.tooltip.sounds_enabled": "切換提示音效。關閉後，所有進度提示音效將被靜音。",
+  "fancytoasts.tooltip.anchor": "設定進度提示在畫面上的定位錨點。座標「x」和「y」是基於錨點的偏移量。",
+  "fancytoasts.tooltip.screen_behavior": "設定開啟介面（如背包、儲物箱等）時進度提示的渲染方式。",
+  "fancytoasts.tooltip.reload_customs": "重新載入所有基於設定檔的內容（如材質），並更新上方列表中的項目。",
+  "fancytoasts.tooltip.loops_strength": "控制正弦/餘弦波的強度，數值越大波動越明顯。",
+  "fancytoasts.tooltip.loops_speed": "控制正弦/餘弦波的速度，數值越大波動越快。",
+  "fancytoasts.tooltip.pitch_randomness": "播放音效時套用隨機音調變化，避免過於重複。0% 表示無音調變化。",
+  "fancytoasts.tooltip.animation_speed": "控制動畫速度的倍率係數。",
+  "fancytoasts.tooltip.toasts_filtering": "需要重新啟動 Minecraft 才能生效。若要封鎖單一進度，請在「toastsToIgnore」中輸入「namespace:category/advancement」。若要封鎖整個類別，請輸入「namespace:category/...」。",
+  "fancytoasts.tooltip.display_text.default": "將動畫中的預設內容顯示為提示的標題或描述。",
+  "fancytoasts.tooltip.display_text.title": "將進度的標題顯示為提示的標題或描述。",
+  "fancytoasts.tooltip.display_text.description": "將進度的描述顯示為提示的標題或描述。",
+  "fancytoasts.tooltip.display_text.announcement": "將進度的公告顯示為提示的標題或描述。",
 
   "fancytoasts.toast.animation.standard": "標準",
   "fancytoasts.toast.animation.standard.description": "標準動畫。平穩柔和，滑動順暢。帶有原版風格",
@@ -108,8 +108,8 @@
   "fancytoasts.toast.animation.playful.description": "活力！趣味！遊戲感十足！這是一種充滿活力、更加實驗性的動畫",
   "fancytoasts.toast.animation.quirky": "古怪",
   "fancytoasts.toast.animation.quirky.description": "搖晃又狂野，永遠在動，從不停下",
-  "fancytoasts.toast.animation.oldlike": "復古風格", // Machine translation
-  "fancytoasts.toast.animation.oldlike.description": "今天想來點華麗的感覺嗎？靈感來自舊式的進度提示。從右向左滑入。帶有透明的出現效果", // Machine translation
+  "fancytoasts.toast.animation.oldlike": "懷舊風格",
+  "fancytoasts.toast.animation.oldlike.description": "今天想來點優雅風？靈感源自經典的老式進度提示。從右向左滑入，伴隨透明漸顯效果。",
 
   "fancytoasts.toast.texture.vanilla": "原版風格",
   "fancytoasts.toast.texture.vanilla.description": "受原版 Minecraft 風格啟發",
@@ -123,14 +123,14 @@
   "fancytoasts.toast.texture.terracraft.description": "那是什麼？我好像看到天上有隻巨大的紅眼！喔不，它在衝刺……靈感來自 Terraria",
   "fancytoasts.toast.texture.steamy": "蒸氣風格",
   "fancytoasts.toast.texture.steamy.description": "我花了 1500 小時才拿到 100%！媽媽，妳為我驕傲嗎？靈感來自 Steam",
-  "fancytoasts.toast.texture.landspaper": "報紙", // Machine translation
-  "fancytoasts.toast.texture.landspaper.description": "我想你收到了一封新信件！或許可以把它釘在某處以便仔細閱讀。希望它不會受潮溶解", // Machine translation
-  "fancytoasts.toast.texture.neon": "霓虹", // Machine translation
-  "fancytoasts.toast.texture.neon.description": "想要一些更暗黑的氛圍嗎？你知道的，霓虹招牌在夜裡總是格外引人注目", // Machine translation
+  "fancytoasts.toast.texture.landspaper": "信紙風格",
+  "fancytoasts.toast.texture.landspaper.description": "好像收到了一封新信！不妨把它釘在牆上仔細端詳。希望它不會受潮化掉。",
+  "fancytoasts.toast.texture.neon": "霓虹",
+  "fancytoasts.toast.texture.neon.description": "喜歡暗黑氛圍？霓虹燈牌在夜裡可是格外迷人哦。",
 
   "fancytoasts.toast.sound.minecraft.description": "Minecraft 內建音效",
-  "fancytoasts.toast.sound.mod.description": "來自模組的音效", // Machine translation
-  "fancytoasts.toast.sound.resourcepack.description": "來自資源包的音效", // Machine translation
+  "fancytoasts.toast.sound.mod.description": "來自模組的音效",
+  "fancytoasts.toast.sound.resourcepack.description": "來自資源包的音效",
 
-  "key.fancytoasts.config_menu": "Fancy Toasts 選單" // Machine translation
+  "key.fancytoasts.config_menu": "Fancy Toasts 設定選單"
 }


### PR DESCRIPTION
Hi! I've updated both `zh_cn` (Simplified Chinese) and `zh_tw` (Traditional Chinese) translations. Here's what I did:

- Fixed lots of machine-translated and outdated entries, making everything read much smoother;
- Unified terminology across the board (e.g., "Toast" → "提示", "Anchor" → "锚点/錨點", "Boss Bar" → "BOSS 栏/Boss 條");
- Polished the descriptions for animations and textures to better match their theme names (e.g., "Playful", "Quirky", "Neon") while keeping the original fun and lively tone;
- Added all missing strings for 1.4.7, and synced the Traditional Chinese version accordingly.

If you're looking for translations that are accurate, natural, and a bit fancy – now you've got it. Feel free to ping me if anything looks off. Thanks to the author and the community!

<details>
<summary>中文</summary>
嗨～这次更新了 `zh_cn` 和 `zh_tw` 两个翻译文件，主要做了下面这些事：

- 修了一大波机翻和旧版遗留的错误翻译，现在读起来更顺畅了；
- 统一了术语，比如 “Toast” → “提示”，“Anchor” → “锚点/錨點”，“Boss Bar” → “BOSS 栏/Boss 條” 等；
- 给动画和材质的描述润了润色，让文字更贴合主题名称（比如 “活泼”、“搞怪”、“霓虹”），同时保留了原文那种轻松有趣的语气；
- 补全了 1.4.7 版本新增的字符串，繁体中文也同步更新了。

如果你喜欢更「雅」一点的翻译，现在应该能感觉到了～有问题随时提，谢谢作者大大和社区！
</details>